### PR TITLE
Show the default `text` case as well

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,6 +47,10 @@
   </header>
 
   <main class="container">
+    <br><code>inputmode=text</code> <em>(default)</em>
+    <br>
+    <input inputmode="text">
+    <hr>
     <br><code>inputmode=decimal</code>
     <br>
     <input inputmode="decimal">

--- a/docs/style.css
+++ b/docs/style.css
@@ -22,7 +22,7 @@ main {
   min-height: 80vh;
 }
 
-code {
+code, em {
   color: hotpink;
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }


### PR DESCRIPTION
## Description

This adds the default input mode as a showcase

## Motivation and Context

It makes it easier for people non-familiar with the different options to go through all of them, and select the appropriate one

## How Has This Been Tested?

Validated on Safari iOS

## Screenshots (if appropriate):

![Screenshot 2020-08-20 at 13 23 35](https://user-images.githubusercontent.com/2778689/90764272-60a5f380-e2e8-11ea-81f0-8911451cb8b1.png)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.

**Note:** I did not update the minified `.css` file as that could lead to a massive clash if other PRs were submitted
